### PR TITLE
[SA-25734] Passwords for new users must have a 60-day maximum password lifetime restriction (V-260546)

### DIFF
--- a/src/start
+++ b/src/start
@@ -160,3 +160,8 @@ fi
 if ! cz-config get kernel/cmdlineOptions | grep audit=1 >/dev/null; then
     cz-config set kernel/cmdlineOptions "$(cz-config get kernel/cmdlineOptions) audit=1"
 fi
+
+#https://www.stigviewer.com/stig/canonical_ubuntu_20.04_lts/2022-09-07/finding/V-260546
+#Ubuntu 22.04 LTS must enforce a 60-day maximum password lifetime restriction.
+#Passwords for new users must have a 60-day maximum password lifetime restriction.
+sed -i -r 's:(PASS_MAX_DAYS\s+)[0-9]+:\160:g' /etc/login.defs

--- a/src/stop
+++ b/src/stop
@@ -23,8 +23,8 @@ rm /etc/security/pwquality.conf
 #V-219303
 sed -i "s:900:1800:g" /etc/profile.d/autologout.sh
 
-#V-219328
-sed -i "s:K 077:K 027:g" /etc/login.defs
+#V-219328 & V-260546
+cp /mnt/root-to/etc/login.defs /etc/login.defs
 
 #V-219339
 rm /etc/modprobe.d/DISASTIG.conf


### PR DESCRIPTION
I changed the stop to replace `/etc/login.defs` from the version coming from the appliance image in the read-only partition.