### PR TITLE
[SA-25734] library files must be group-owned by "root" (V-260500)

### DIFF
--- a/src/start
+++ b/src/start
@@ -201,3 +201,15 @@ systemctl restart sshd.service
 # Monitor remote access methods
 cp "$BASE_DIR/data/55-auth.conf" /etc/rsyslog.d/
 systemctl restart rsyslog
+
+#https://stigviewer.com/stig/canonical_ubuntu_22.04_lts/2024-05-30/finding/V-260500
+#library files must be group-owned by "root".
+#NOTE: /lib is a symlink to /usr/lib
+FILES="\
+/usr/lib/x86_64-linux-gnu/utempter/utempter \
+/usr/lib/dbus-1.0/dbus-daemon-launch-helper \
+/usr/lib/ssl/private/ssl-cert-snakeoil.key \
+"
+for FILE in $FILES; do
+    chgrp root "$FILE"
+done


### PR DESCRIPTION
The original permissions are:
```
-rwxr-sr-x 1 root utmp 15K Mar 24  2022 /usr/lib/x86_64-linux-gnu/utempter/utempter
-rwsr-xr-- 1 root messagebus 35K Oct 25  2022 /usr/lib/dbus-1.0/dbus-daemon-launch-helper
-rw-r----- 1 root ssl-cert 1.7K Feb 26 16:26 /usr/lib/ssl/private/ssl-cert-snakeoil.key
```

after:
```
-rwxr-xr-x 1 root root 15K Mar 24  2022 /usr/lib/x86_64-linux-gnu/utempter/utempter
-rwxr-xr-- 1 root root 35K Oct 25  2022 /usr/lib/dbus-1.0/dbus-daemon-launch-helper
-rw-r----- 1 root root 1.7K Feb 26 16:26 /usr/lib/ssl/private/ssl-cert-snakeoil.key
```